### PR TITLE
handle `project-switch-commands` being a function instead of a list

### DIFF
--- a/README.org
+++ b/README.org
@@ -54,6 +54,20 @@ OR, if you do not want to use the (opinionated) minor-mode =project-x-mode=,
              ("C-x p j" . project-x-window-state-load)))
 #+end_src
 
+OR, to automatically reload the windows when switching to a project,
+
+#+begin_src emacs-lisp
+  (use-package project-x
+    :load-path "~/path/to/project-x/"
+    :after project
+    :config
+    (add-hook 'project-find-functions 'project-x-try-local 90)
+    (add-hook 'kill-emacs-hook 'project-x--window-state-write)
+    (setq project-switch-commands #'project-x-windows)
+    :bind (("C-x p w" . project-x-window-state-save)
+	   ("C-x p j" . project-x-window-state-load))))
+#+end_src
+
 There are three customization options right now:
 - =project-x-window-list-file=: File to store project window configurations. Defaults to your emacs config directory.
 - =project-x-local-identifier=: String matched against file names to decide if a directory (or some parent thereof) is a project. Defaults to =.project=. You can also supply a list of strings instead. For example, node projects use a file named =package.json= to denote the root of a project, Elixir uses =mix.exs= and Julia uses =Project.toml=. You can use project-x to identify all of the above as project directories by setting

--- a/project-x.el
+++ b/project-x.el
@@ -196,8 +196,10 @@ contains) a special file as a project."
         (project-x--window-state-read)
         (define-key project-prefix-map (kbd "w") 'project-x-window-state-save)
         (define-key project-prefix-map (kbd "j") 'project-x-window-state-load)
-        (add-to-list 'project-switch-commands
-                     '(?j "Restore windows" project-x-windows) t)
+        (if (listp project-switch-commands)
+            (add-to-list 'project-switch-commands
+                         '(?j "Restore windows" project-x-windows) t)
+          (message "`project-switch-commands` is not a list, not adding 'restore windows' command"))
         (when project-x-save-interval
           (setq project-x-save-timer
                 (run-with-timer 0 (max project-x-save-interval 5)
@@ -206,7 +208,8 @@ contains) a special file as a project."
     (remove-hook 'kill-emacs-hook 'project-x--window-state-write)
     (define-key project-prefix-map (kbd "w") nil)
     (define-key project-prefix-map (kbd "j") nil)
-    (delete '(?j "Restore windows" project-x-windows) project-switch-commands)
+    (when (listp project-switch-commands)
+      (delete '(?j "Restore windows" project-x-windows) project-switch-commands))
     (when (timerp project-x-save-timer)
       (cancel-timer project-x-save-timer))))
 


### PR DESCRIPTION
project.el's `project-switch-commands` can be set to either a list of functions that the user can select from, or a single function that's run without a prompt.  This PR lets `project-x` work when it's a function, and documents how to use that to automatically load the saved window config (if any) on project switch.